### PR TITLE
Removing path in config for Trestle.

### DIFF
--- a/config/initializers/trestle.rb
+++ b/config/initializers/trestle.rb
@@ -24,7 +24,7 @@ Trestle.configure do |config|
   #
   # Set the path at which to mount the Trestle admin. Defaults to /admin.
   #
-   config.path = "/tupress/admin"
+  #config.path = "/tupress/admin"
 
   # Toggle whether Trestle should automatically mount the admin within your
   # Rails application's routes. Defaults to true.


### PR DESCRIPTION
Removing path "/tupress/admin/" in config for Trestle. Defualts to "/admin/".