### PR TITLE
Removed trestle_title variable in overridden sidebar file because var…

### DIFF
--- a/app/views/trestle/shared/_sidebar.html.erb
+++ b/app/views/trestle/shared/_sidebar.html.erb
@@ -7,7 +7,8 @@
       <span class="icon-bar"></span>
     </button>
 
-    <%= link_to trestle_title, "/", class: "navbar-brand" %>
+    <%= link_to "Tupress", "/", class: "navbar-brand" %>
+
   </header>
 
   <div class="app-sidebar-inner">


### PR DESCRIPTION
…iable is no longer used by trestle.