### PR TITLE
Add Prod Deploy on releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,15 @@ workflows:
          filters:
            branches:
              only:
-               - master
-  # prod_deploy:
-  #   jobs:
-  #     - prod_deploy:
-  #         filters:
-  #           branches:
-  #             ignore: /.*/
-  #           tags:
-  #             only: /^v[0-9]+(\.[0-9]+)*$/
+               - main
+  prod_deploy:
+    jobs:
+      - prod_deploy:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
 
 jobs:
   run_tests:
@@ -54,16 +54,16 @@ jobs:
       - run:
           command: bash .circleci/deploy-qa.sh
 
-    # prod_deploy:
-    # docker:
-    #   - image: circleci/python:3.6.6
-    #     environment:
-    #       PIPENV_VENV_IN_PROJECT: true
-    # steps:
-    #   - checkout
-    #   - add_ssh_keys:
-    #       fingerprints:
-    #         - "08:05:8e:1f:ff:2e:4d:59:60:3e:a2:d5:e3:e2:b8:68"
-    #         - "3e:58:05:d9:83:6b:a2:76:dd:12:94:fe:e4:3f:44:cb"
-    #   - run:
-    #       command: bash .circleci/deploy-prod.sh
+  prod_deploy:
+    docker:
+      - image: circleci/python:3.7.2
+        environment:
+          PIPENV_VENV_IN_PROJECT: true
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "08:05:8e:1f:ff:2e:4d:59:60:3e:a2:d5:e3:e2:b8:68"
+            - "3e:58:05:d9:83:6b:a2:76:dd:12:94:fe:e4:3f:44:cb"
+      - run:
+          command: bash .circleci/deploy-prod.sh

--- a/.circleci/deploy-prod.sh
+++ b/.circleci/deploy-prod.sh
@@ -3,7 +3,7 @@ set -e
 
 cd ..
 # clone deployment playbook
-git clone --single-branch --branch main git@github.com:tulibraries/tupress_playbook.git
+git clone --single-branch --branch master git@github.com:tulibraries/tupress_playbook.git
 cd tupress_playbook
 # install playbook requirements
 sudo pip install pipenv

--- a/README.md
+++ b/README.md
@@ -1,23 +1,19 @@
-# README
+# Temple University Press Website
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+# Local Development
+TODO!
 
-Things you may want to cover:
+# Running Tests
+TODO!
 
-* Ruby version
+#CI / CD
 
-* System dependencies
+This repository uses CircleCI to deploy to qa and prod, using [Ansible Playbook](https://github.com/tulibraries/tupress_playbook)
 
-* Configuration
+Merges to master use trigger a deploy to [QA](https://tupress.qa.tul-infra.page/).
 
-* Database creation
 
-* Database initialization
+Creating a release triggers a deploy to [Prod](http://tupress.temple.edu/)
 
-* How to run the test suite
 
-* Services (job queues, cache servers, search engines, etc.)
 
-* Deployment instructions
-* HOLA!


### PR DESCRIPTION
Creating a release will now trigger a deploy to production.

Also updates circle config to use main instead of master.

Adds a very bare bones readme.