### PR TITLE
#TWM-89 TUPRESS: cannot access to edit the admin site (HIGH)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'autoprefixer-rails'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'bootstrap', '~> 4.5.0'
+gem 'sprockets', '= 3.7.2'
 gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -321,6 +321,7 @@ DEPENDENCIES
   social-share-button
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (= 3.7.2)
   sqlite3
   tinymce-rails
   trestle (= 0.8.11)


### PR DESCRIPTION
Revert upgrade of sprockets from 3.7.2 to 4.0.0 due to Trestle conflicts. Lock version at 3.7.2 in Gemfile.